### PR TITLE
[chore] Remove high cardinality `job_id` label from Loki

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,7 @@ The **Send Logs to Loki** GitHub Action collects logs from all jobs in a GitHub 
 - **Loki Endpoint**: Specify the Loki instance URL with `loki_endpoint`.
 - **Retry Configuration**: Use the `max_retries` and `retry_interval_seconds` inputs to control log fetch retry behavior.
 
-By default, the `job_id` and `job_name` are automatically added as labels for each job. (Be mindful of cardinality!)
+By default, `job_name` are automatically added as labels for each job. (Be mindful of cardinality!)
 
 ## Dependencies
 

--- a/push_logs.py
+++ b/push_logs.py
@@ -98,7 +98,7 @@ def main():
 
         if logs_to_send:
             print(f"Sending {len(logs_to_send)} log lines to Loki for job {name}...")
-            push_to_loki(logs_to_send, LABELS, job_name=name, job_id=job_id)
+            push_to_loki(logs_to_send, LABELS, job_name=name)
         else:
             print(f"No logs to send for job {name}.")
 


### PR DESCRIPTION
The `job_id` label can cause high cardinality in Loki metrics, which can impact performance and storage. To follow best practices, we are removing it from label injection.