### PR TITLE
feat: Add the option to send a custom message to Loki, bypassing GitH…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## [v0.0.3] - 2025-11-13
+### Added
+- Support for `message_to_loki` input and `MESSAGE_TO_LOKI` environment variable. If set, the action sends only this message to Loki and skips all GitHub Actions logs.
+- Updated documentation and usage examples to reflect the new feature.
+- Modularized the Python script for better maintainability.
+
+### Changed
+- `action.yml` now includes the `message_to_loki` input and passes it to the script.
+- README updated to document the new input and usage.
+
+---
+
+# Release Notes
+
+## v0.0.3
+- **Feature:** You can now send a custom message to Loki by setting the `message_to_loki` input (or `MESSAGE_TO_LOKI` environment variable). When this is set, the action will ignore all GitHub Actions logs and send only the provided message.
+- **Improvement:** The Python script is now more modular and easier to maintain.
+- **Documentation:** All usage instructions and examples have been updated to reflect the new feature.

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@ The **Send Logs to Loki** GitHub Action collects logs from all jobs in a GitHub 
 - Aggregates logs from all jobs in a workflow, including job-specific logs.
 - Allows dynamic injection of custom labels.
 - Automatically retries fetching logs if they are not immediately available.
+- **NEW:** Optionally send a custom message to Loki, bypassing GitHub Actions logs.
 
 ## Inputs
 
@@ -16,7 +17,8 @@ The **Send Logs to Loki** GitHub Action collects logs from all jobs in a GitHub 
 | `labels`                | Custom labels for logs (comma-separated key=value pairs)   | No       | `job=github-actions` |
 | `github_token`          | GitHub token for API authentication                        | Yes      |                      |
 | `max_retries`           | Maximum number of retry attempts for fetching logs per job | No      |  5                   |
-| `retry_interval_seconds`| Interval in seconds between retry attempts                 | No      |  10                   |
+| `retry_interval_seconds`| Interval in seconds between retry attempts                 | No      |  10                  |
+| `message_to_loki`       | Custom message to send directly to Loki (skips job logs)   | No      |                      |
 
 ## Example Usage
 
@@ -31,16 +33,20 @@ The **Send Logs to Loki** GitHub Action collects logs from all jobs in a GitHub 
     loki_endpoint: "https://loki.example.com"
     labels: "job=github-actions,run_id=${{ github.run_id }}"
     github_token: ${{ secrets.GITHUB_TOKEN }}
+    message_to_loki: "Deployment started by ${{ github.actor }}"
 ```
 
 ## How It Works
 
-1. **Log Aggregation**: The action iterates over all jobs in the workflow using the GitHub Actions API.
-2. **Log Retrieval**: Logs are fetched for completed jobs and skipped for jobs still in progress.
-3. **Log Transmission**: Logs are sent to Loki with the specified labels.
+1. **Custom Message Mode**: If the `message_to_loki` input (or `MESSAGE_TO_LOKI` env var) is set, the action sends only this message to Loki and skips all GitHub Actions logs.
+2. **Log Aggregation**: Otherwise, the action iterates over all jobs in the workflow using the GitHub Actions API.
+3. **Log Retrieval**: Logs are fetched for completed jobs and skipped for jobs still in progress.
+4. **Log Transmission**: Logs are sent to Loki with the specified labels.
 
 ## How to Configure
 
+- **Send a Custom Message**: Set the `message_to_loki` input (or `MESSAGE_TO_LOKI` environment variable) to send a single message to Loki, ignoring all job logs.
+  - Example: `message_to_loki: "Manual trigger by admin"`
 - **Add Custom Labels**: Use the `labels` input to include additional metadata for your logs.
   - Example: `labels: "job=github-actions,env=production"`
 - **Loki Endpoint**: Specify the Loki instance URL with `loki_endpoint`.

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: "Interval in seconds between retry attempts"
     required: false
     default: "10"
+  message_to_loki:
+    description: "Custom message to send directly to Loki (skips job logs)"
+    required: false
 
 runs:
   using: "composite"
@@ -38,4 +41,5 @@ runs:
         LABELS: ${{ inputs.labels }}
         MAX_RETRIES: ${{ inputs.max_retries }}
         RETRY_INTERVAL_SECONDS: ${{ inputs.retry_interval_seconds }}
+        MESSAGE_TO_LOKI: ${{ inputs.message_to_loki }}
       run: python3 "$GITHUB_ACTION_PATH/push_logs.py"

--- a/push_logs.py
+++ b/push_logs.py
@@ -4,16 +4,20 @@ import requests
 import re
 import time
 
-# Environment Variables
-GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
-RUN_ID = os.getenv("RUN_ID")
-LOKI_ENDPOINT = os.getenv("LOKI_ENDPOINT")
-LABELS = os.getenv("LABELS", "job=github-actions")
-GITHUB_REPO = os.getenv("GITHUB_REPOSITORY")
-MAX_RETRIES = int(os.getenv("MAX_RETRIES", 5))  # Defaults to 5 retries if not setup in the action
-RETRY_INTERVAL_SECONDS = int(os.getenv("RETRY_INTERVAL_SECONDS", 10))  # Defaults to 10 seconds if not setup in the action
 
-HEADERS = {"Authorization": f"Bearer {GITHUB_TOKEN}", "Accept": "application/vnd.github.v3+json"}
+
+def load_env():
+    env = {}
+    env["GITHUB_TOKEN"] = os.getenv("GITHUB_TOKEN")
+    env["RUN_ID"] = os.getenv("RUN_ID")
+    env["LOKI_ENDPOINT"] = os.getenv("LOKI_ENDPOINT")
+    env["LABELS"] = os.getenv("LABELS", "job=github-actions")
+    env["GITHUB_REPO"] = os.getenv("GITHUB_REPOSITORY")
+    env["MAX_RETRIES"] = int(os.getenv("MAX_RETRIES", 5))
+    env["RETRY_INTERVAL_SECONDS"] = int(os.getenv("RETRY_INTERVAL_SECONDS", 10))
+    env["MESSAGE_TO_LOKI"] = os.getenv("MESSAGE_TO_LOKI")
+    env["HEADERS"] = {"Authorization": f"Bearer {env['GITHUB_TOKEN']}", "Accept": "application/vnd.github.v3+json"}
+    return env
 
 def sanitize_labels(labels):
     """Sanitize labels to comply with Loki's label naming rules."""
@@ -26,19 +30,19 @@ def sanitize_labels(labels):
         sanitized[key] = v
     return sanitized
 
-def get_jobs(run_id):
+def get_jobs(run_id, github_repo, headers):
     """Fetch all jobs metadata for the current workflow run."""
     print(f"Fetching job metadata for workflow run ID: {run_id}")
-    jobs_url = f"https://api.github.com/repos/{GITHUB_REPO}/actions/runs/{run_id}/jobs"
-    response = requests.get(jobs_url, headers=HEADERS)
+    jobs_url = f"https://api.github.com/repos/{github_repo}/actions/runs/{run_id}/jobs"
+    response = requests.get(jobs_url, headers=headers)
     if response.status_code != 200:
         raise Exception(f"Failed to fetch jobs: {response.text}")
     return response.json().get("jobs", [])
 
-def fetch_job_logs(job_id):
+def fetch_job_logs(job_id, github_repo, headers):
     """Fetch logs for a specific job."""
-    logs_url = f"https://api.github.com/repos/{GITHUB_REPO}/actions/jobs/{job_id}/logs"
-    response = requests.get(logs_url, headers=HEADERS)
+    logs_url = f"https://api.github.com/repos/{github_repo}/actions/jobs/{job_id}/logs"
+    response = requests.get(logs_url, headers=headers)
     if response.status_code == 200:
         return response.text.splitlines()
     elif response.status_code == 403:
@@ -48,7 +52,7 @@ def fetch_job_logs(job_id):
         print(f"Failed to fetch logs for job {job_id}: {response.status_code}")
         return []
 
-def push_to_loki(logs, labels, job_name=None, job_id=None):
+def push_to_loki(logs, labels, loki_endpoint, job_name=None, job_id=None):
     """Push logs to Loki."""
     # Add job name and job ID as additional labels if provided
     if job_name:
@@ -67,15 +71,21 @@ def push_to_loki(logs, labels, job_name=None, job_id=None):
             }
         ]
     }
-    print(f"Pushing logs to Loki: {LOKI_ENDPOINT}")
-    response = requests.post(f"{LOKI_ENDPOINT}/loki/api/v1/push", json=payload)
+    print(f"Pushing logs to Loki: {loki_endpoint}")
+    response = requests.post(f"{loki_endpoint}/loki/api/v1/push", json=payload)
     if response.status_code == 204:
         print("Logs successfully sent to Loki.")
     else:
         print(f"Failed to send logs to Loki: {response.status_code}, {response.text}")
 
-def main():
-    jobs = get_jobs(RUN_ID)
+
+
+def send_custom_message_to_loki(message, labels, loki_endpoint):
+    print("MESSAGE_TO_LOKI is set. Sending only this message to Loki and skipping GitHub Actions logs.")
+    push_to_loki([message], labels, loki_endpoint)
+
+def send_github_logs_to_loki(env):
+    jobs = get_jobs(env["RUN_ID"], env["GITHUB_REPO"], env["HEADERS"])
     for job in jobs:
         job_id = job.get("id")
         status = job.get("status")
@@ -87,20 +97,27 @@ def main():
             continue
 
         logs_to_send = []
-        for attempt in range(1, MAX_RETRIES + 1):
-            print(f"Fetching logs for job ID: {job_id} (Attempt {attempt}/{MAX_RETRIES})")
-            logs = fetch_job_logs(job_id)
+        for attempt in range(1, env["MAX_RETRIES"] + 1):
+            print(f"Fetching logs for job ID: {job_id} (Attempt {attempt}/{env['MAX_RETRIES']})")
+            logs = fetch_job_logs(job_id, env["GITHUB_REPO"], env["HEADERS"])
             if logs:
                 logs_to_send.extend(logs)
                 break  # Stop retrying once logs are fetched
-            print(f"No logs available yet for job ID: {job_id}. Retrying in {RETRY_INTERVAL_SECONDS} seconds...")
-            time.sleep(RETRY_INTERVAL_SECONDS)
+            print(f"No logs available yet for job ID: {job_id}. Retrying in {env['RETRY_INTERVAL_SECONDS']} seconds...")
+            time.sleep(env["RETRY_INTERVAL_SECONDS"])
 
         if logs_to_send:
             print(f"Sending {len(logs_to_send)} log lines to Loki for job {name}...")
-            push_to_loki(logs_to_send, LABELS, job_name=name)
+            push_to_loki(logs_to_send, env["LABELS"], env["LOKI_ENDPOINT"], job_name=name)
         else:
             print(f"No logs to send for job {name}.")
+
+def main():
+    env = load_env()
+    if env["MESSAGE_TO_LOKI"]:
+        send_custom_message_to_loki(env["MESSAGE_TO_LOKI"], env["LABELS"], env["LOKI_ENDPOINT"])
+    else:
+        send_github_logs_to_loki(env)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
…ub Actions logs

Add support for sending custom message. In this case, only the provided message is sent to Loki, skipping all GitHub Actions logs.